### PR TITLE
Remove session recreation from report generation method.

### DIFF
--- a/ZohoBooksReports.ipynb
+++ b/ZohoBooksReports.ipynb
@@ -410,10 +410,7 @@
         "  total_intra_state_tax_df = intra_state_tax_df[['Amount (excluding GST)','CGST Amount','SGST Amount','Amount (including GST)']].sum().to_frame(name=\"Total\")\n",
         "  return invoice_df, sales_type_df, intra_state_tax_df, total_intra_state_tax_df\n",
         "\n",
-        "def generateReport(from_date=None, to_date=None):\n",
-        "  oauth_token = renewOauthToken('1000.8e82d21986ea040cf450df7a7afee4d8.84fa32b03a3316dbbdcba8033e4fc3ed',CLIENT_ID, CLIENT_SECRET)\n",
-        "  session = createSession(oauth_token['access_token'])\n",
-        "\n",
+        "def generateReport(session, from_date=None, to_date=None):\n",
         "  report_data = createDataForReporting(session, from_date, to_date)\n",
         "  time_range = FOR_DATE.format(for_date=from_date) if from_date == to_date else FROM_TO_DATE.format(from_date=from_date, to_date=to_date)\n",
         "\n",
@@ -486,84 +483,14 @@
       "source": [
         "# @title Report\n",
         "\n",
-        "invoice_df, sales_type_df, intra_state_tax_df, total_intra_state_tax_df = generateReport(from_date=FROM_DATE, to_date=TO_DATE)"
+        "invoice_df, sales_type_df, intra_state_tax_df, total_intra_state_tax_df = generateReport(session=session, from_date=FROM_DATE, to_date=TO_DATE)"
       ],
       "metadata": {
         "id": "1JWCT2IPD_l9",
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 17
-        },
-        "outputId": "de1a5689-ee93-4c34-8140-14dace63f688"
+        "cellView": "form"
       },
       "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "\n",
-              "    async function download(id, filename, size) {\n",
-              "      if (!google.colab.kernel.accessAllowed) {\n",
-              "        return;\n",
-              "      }\n",
-              "      const div = document.createElement('div');\n",
-              "      const label = document.createElement('label');\n",
-              "      label.textContent = `Downloading \"${filename}\": `;\n",
-              "      div.appendChild(label);\n",
-              "      const progress = document.createElement('progress');\n",
-              "      progress.max = size;\n",
-              "      div.appendChild(progress);\n",
-              "      document.body.appendChild(div);\n",
-              "\n",
-              "      const buffers = [];\n",
-              "      let downloaded = 0;\n",
-              "\n",
-              "      const channel = await google.colab.kernel.comms.open(id);\n",
-              "      // Send a message to notify the kernel that we're ready.\n",
-              "      channel.send({})\n",
-              "\n",
-              "      for await (const message of channel.messages) {\n",
-              "        // Send a message to notify the kernel that we're ready.\n",
-              "        channel.send({})\n",
-              "        if (message.buffers) {\n",
-              "          for (const buffer of message.buffers) {\n",
-              "            buffers.push(buffer);\n",
-              "            downloaded += buffer.byteLength;\n",
-              "            progress.value = downloaded;\n",
-              "          }\n",
-              "        }\n",
-              "      }\n",
-              "      const blob = new Blob(buffers, {type: 'application/binary'});\n",
-              "      const a = document.createElement('a');\n",
-              "      a.href = window.URL.createObjectURL(blob);\n",
-              "      a.download = filename;\n",
-              "      div.appendChild(a);\n",
-              "      a.click();\n",
-              "      div.remove();\n",
-              "    }\n",
-              "  "
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "download(\"download_c709dd94-ef22-43a9-819e-3d4ab8dc54b9\", \"report-from-2024-04-01-to-2024-04-01.xlsx\", 9767)"
-            ]
-          },
-          "metadata": {}
-        }
-      ]
+      "outputs": []
     },
     {
       "cell_type": "code",


### PR DESCRIPTION
Only one session will be used for all API calls.