### PR TITLE
Do not round CGST and SGST amounts.

### DIFF
--- a/ZohoBooksReports.ipynb
+++ b/ZohoBooksReports.ipynb
@@ -97,8 +97,8 @@
       "source": [
         "# @title Date Config\n",
         "\n",
-        "FROM_DATE = '2024-04-05' # @param {type:\"date\"}\n",
-        "TO_DATE = '2024-04-05' # @param {type:\"date\"}\n",
+        "FROM_DATE = '' # @param {type:\"date\"}\n",
+        "TO_DATE = '' # @param {type:\"date\"}\n",
         "\n",
         "DATE_FORMAT = '%Y-%m-%d'\n",
         "if datetime.strptime(FROM_DATE, DATE_FORMAT) > datetime.strptime(TO_DATE, DATE_FORMAT):\n",
@@ -166,7 +166,8 @@
         "REPORT_TITLE = \"\""
       ],
       "metadata": {
-        "id": "Vs6hpVxImH3X"
+        "id": "Vs6hpVxImH3X",
+        "cellView": "form"
       },
       "execution_count": null,
       "outputs": []
@@ -552,7 +553,7 @@
         "      self.data_rows.append({'Invoice No.' : invoice['invoice_number'],\n",
         "                            'Time' : formatTimestamp(invoice['created_time']),\n",
         "                            'Payment Mode' : payment_mode,\n",
-        "                            'Amount (including tax)' : round(invoice['bcy_total'])})\n",
+        "                            'Amount (including GST)' : round(invoice['bcy_total'])})\n",
         "\n",
         "\n",
         "class SalesTypeTable(Table):\n",
@@ -591,8 +592,8 @@
         "                            'Invoice No.' : invoice['invoice_number'],\n",
         "                            'SKU' : item['sku'],\n",
         "                            'Amount (excluding GST)' : round(item['item_total']),\n",
-        "                            'CGST Amount' : round(cgst_amount),\n",
-        "                            'SGST Amount' : round(sgst_amount),\n",
+        "                            'CGST Amount' : cgst_amount,\n",
+        "                            'SGST Amount' : sgst_amount,\n",
         "                            'CGST Percent' : cgst_percent,\n",
         "                            'SGST Percent' : sgst_percent,\n",
         "                            'Amount (including GST)' : round(calculate_tax_inclusive_amount(item))})\n",


### PR DESCRIPTION
Important to preserve CGST and SGST precise values for tax computation.