### PR TITLE
Changes to handle API Rate Limit Exceeded for Monthly GST Report.

### DIFF
--- a/ZohoBooksReports.ipynb
+++ b/ZohoBooksReports.ipynb
@@ -21,6 +21,17 @@
     },
     {
       "cell_type": "code",
+      "source": [
+        "!pip install ratelimit"
+      ],
+      "metadata": {
+        "id": "yjTAub1V2SNm"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
       "metadata": {
         "id": "X2R6Z2uxBIbk"
@@ -36,7 +47,10 @@
         "import pandas as pd\n",
         "import pytz\n",
         "import re\n",
-        "import requests"
+        "import requests\n",
+        "import time\n",
+        "from ratelimit import limits, sleep_and_retry\n",
+        "from tqdm.notebook import tqdm"
       ]
     },
     {
@@ -65,7 +79,7 @@
       "source": [
         "# @title Access Config\n",
         "\n",
-        "ORGANIZATION_ID = None # @param {type:\"integer\"}\n",
+        "ORGANIZATION_ID = 0 # @param {type:\"integer\"}\n",
         "AUTH_TOKEN = \"\" # @param {type:\"string\"}\n",
         "CLIENT_ID = \"\" # @param {type:\"string\"}\n",
         "CLIENT_SECRET = \"\" # @param {type:\"string\"}\n",
@@ -97,8 +111,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "7KHJ-fX-AB-x"
+        "id": "7KHJ-fX-AB-x",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -126,10 +140,10 @@
         "# @title Report Config\n",
         "\n",
         "DOWNLOAD_EXCEL_REPORT = False # @param {type:\"boolean\"}\n",
-        "DOWNLOAD_HTML_REPORT = False # @param {type:\"boolean\"}\n",
+        "DOWNLOAD_HTML_REPORT = True # @param {type:\"boolean\"}\n",
         "\n",
         "GET_GST_REPORT_ALL = False # @param {type:\"boolean\"}\n",
-        "GET_GST_REPORT_ARTICLES_ONLY = False # @param {type:\"boolean\"}\n",
+        "GET_GST_REPORT_ARTICLES_ONLY = True # @param {type:\"boolean\"}\n",
         "\n",
         "PAYMENT_MODE_CREDIT = \"Credit\"\n",
         "FROM_TO_DATE = \"FROM: {from_date} TO: {to_date}\"\n",
@@ -273,8 +287,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "EuejqBFiJ6k8"
+        "id": "EuejqBFiJ6k8",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -286,14 +300,10 @@
         "  return ist_datetime.strftime(\"%d-%m-%Y %H:%M\")\n",
         "\n",
         "def calculate_tax_inclusive_amount(item):\n",
-        "  disount, discount_adjusted_rate = 0.0, 0.0\n",
-        "  if '%' in str(item['discount']):\n",
-        "    discount = float(item['discount'].strip('%'))/100\n",
-        "    discount_adjusted_rate = item['rate']*(1-discount)\n",
-        "  else:\n",
-        "    discount = item['discount']\n",
-        "    discount_adjusted_rate = item['rate'] - discount\n",
-        "  return item['quantity']*discount_adjusted_rate\n",
+        "  total_tax = 0.0\n",
+        "  for tax in item['line_item_taxes']:\n",
+        "    total_tax += tax['tax_amount']\n",
+        "  return item['item_total'] + total_tax\n",
         "\n",
         "def getItemType(item):\n",
         "  return ITEM_TYPE_BOOK if item['hsn_or_sac'] == '49011010' else ITEM_TYPE_ARTICLE\n",
@@ -315,8 +325,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "YJXgszFgDYmN"
+        "id": "YJXgszFgDYmN",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -351,10 +361,35 @@
     },
     {
       "cell_type": "code",
+      "source": [
+        "# @title API Calls\n",
+        "\n",
+        "ONE_MINUTE = 60\n",
+        "CALLS_PER_MINUTE = 100\n",
+        "\n",
+        "@sleep_and_retry\n",
+        "@limits(calls=CALLS_PER_MINUTE, period=ONE_MINUTE)\n",
+        "def callZohoApi(method, url, data):\n",
+        "  global API_CALLS_COUNTER\n",
+        "  response = method(url=url, data=data)\n",
+        "  API_CALLS_COUNTER += 1\n",
+        "  if response.json()['code'] != 0:\n",
+        "      raise Exception('API response: {}'.format(response.json()['message']))\n",
+        "  return response\n"
+      ],
+      "metadata": {
+        "id": "vYAtqYfN2dGY",
+        "cellView": "form"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "W0fryd4lHtZI"
+        "id": "W0fryd4lHtZI",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -364,11 +399,10 @@
         "  '''\n",
         "    Only takes the first organization from the list of orgs.\n",
         "  '''\n",
-        "  global API_CALLS_COUNTER, ORGANIZATION_ID, ORGANIZATION_NAME\n",
+        "  global ORGANIZATION_ID, ORGANIZATION_NAME\n",
         "  url = ROOT_API_ENDPOINT+'organizations'\n",
         "  payload = {}\n",
-        "  response = session.get(url,data=payload)\n",
-        "  API_CALLS_COUNTER += 1\n",
+        "  response = callZohoApi(method=session.get, url=url, data=payload)\n",
         "  org_info = response.json()\n",
         "  org = org_info['organizations'][0]\n",
         "  print(\"Using Organization: {name}\".format(name=org['name']))\n",
@@ -381,15 +415,14 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "Un_bN28NwAgR"
+        "id": "Un_bN28NwAgR",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
         "# @title Invoices\n",
         "\n",
         "def getInvoices(session, from_date=None, to_date=None, additional_params=None):\n",
-        "  global API_CALLS_COUNTER\n",
         "  params = additional_params if additional_params else []\n",
         "  params.append(\"organization_id={ORGANIZATION_ID}\".format(ORGANIZATION_ID=ORGANIZATION_ID))\n",
         "  params.append(\"per_page={MAX_RECORDS_PER_PAGE}\".format(MAX_RECORDS_PER_PAGE=MAX_RECORDS_PER_PAGE))\n",
@@ -405,9 +438,7 @@
         "  send_request = True\n",
         "  current_page = 1\n",
         "  while send_request:\n",
-        "    response = session.get(url+\"&page={PAGE}\".format(PAGE=current_page),data=payload)\n",
-        "    API_CALLS_COUNTER += 1\n",
-        "    #perform exception handling here\n",
+        "    response = callZohoApi(method=session.get, url=url+\"&page={PAGE}\".format(PAGE=current_page), data=payload)\n",
         "    results += response.json()['invoices']\n",
         "    send_request = response.json()['page_context']['has_more_page']\n",
         "    current_page += 1\n",
@@ -415,41 +446,26 @@
         "  return pd.DataFrame.from_records(results) if results else None\n",
         "\n",
         "def getInvoiceDetails(session, invoice_id):\n",
-        "  global API_CALLS_COUNTER\n",
         "  params = []\n",
         "  params.append(\"organization_id={ORGANIZATION_ID}\".format(ORGANIZATION_ID=ORGANIZATION_ID))\n",
         "  url = ROOT_API_ENDPOINT+\"invoices/{invoice_id}?\".format(invoice_id=invoice_id)+\"&\".join(params)\n",
         "  payload = {}\n",
-        "  response = session.get(url, data=payload)\n",
-        "  API_CALLS_COUNTER += 1\n",
-        "  return response.json()\n",
-        "  #perform exception handling here\n",
-        "\n",
-        "def getPaymentsForInvoice(session, invoice_id):\n",
-        "  global API_CALLS_COUNTER\n",
-        "  params = []\n",
-        "  params.append(\"organization_id={ORGANIZATION_ID}\".format(ORGANIZATION_ID=ORGANIZATION_ID))\n",
-        "  url = ROOT_API_ENDPOINT+\"invoices/{invoice_id}/payments?\".format(invoice_id=invoice_id)+\"&\".join(params)\n",
-        "  payload = {}\n",
-        "  response = session.get(url, data=payload)\n",
-        "  API_CALLS_COUNTER += 1\n",
-        "  return response.json()\n",
-        "  #perform exception handling here"
+        "  response = callZohoApi(method=session.get, url=url, data=payload)\n",
+        "  return response.json()"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "8NiOfTdbUhGf"
+        "id": "8NiOfTdbUhGf",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
         "# @title Payments\n",
         "\n",
         "def getPayments(session, from_date=None, to_date=None):\n",
-        "  global API_CALLS_COUNTER\n",
         "  params = []\n",
         "  params.append(\"organization_id={ORGANIZATION_ID}\".format(ORGANIZATION_ID=ORGANIZATION_ID))\n",
         "  params.append(\"per_page={MAX_RECORDS_PER_PAGE}\".format(MAX_RECORDS_PER_PAGE=MAX_RECORDS_PER_PAGE))\n",
@@ -465,9 +481,7 @@
         "  send_request = True\n",
         "  current_page = 1\n",
         "  while send_request:\n",
-        "    response = session.get(url+\"&page={PAGE}\".format(PAGE=current_page), data=payload)\n",
-        "    API_CALLS_COUNTER += 1\n",
-        "    #perform exception handling here\n",
+        "    response = callZohoApi(method=session.get, url=url+\"&page={PAGE}\".format(PAGE=current_page), data=payload)\n",
         "    results += response.json()['customerpayments']\n",
         "    send_request = response.json()['page_context']['has_more_page']\n",
         "    current_page += 1\n",
@@ -479,8 +493,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "TZMUs0NpGdmV"
+        "id": "TZMUs0NpGdmV",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -708,8 +722,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "5nOIDDC613Fs"
+        "id": "5nOIDDC613Fs",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -718,17 +732,20 @@
         "def fetchDataForReporting(session, from_date=None, to_date=None):\n",
         "  data = []\n",
         "  invoices = getInvoices(session, from_date, to_date)\n",
+        "  payments = getPayments(session, from_date, to_date)\n",
         "  if invoices is None:\n",
         "    return data\n",
         "\n",
         "  invoice_table = DailySalesTable(from_date,to_date)\n",
         "  sales_type_table = SalesTypeTable(from_date,to_date)\n",
         "  intra_state_tax_table = IntraStateTaxTable(from_date, to_date)\n",
-        "  for invoice_id in invoices['invoice_id']:\n",
+        "\n",
+        "  for invoice_id in tqdm(invoices['invoice_id'], total=invoices.shape[0]):\n",
         "    invoice = getInvoiceDetails(session, invoice_id)['invoice']\n",
-        "    payments = getPaymentsForInvoice(session, invoice_id)['payments']\n",
-        "    #assert len(payments) <= 1\n",
-        "    payment_mode = payments[0]['payment_mode'] if payments else PAYMENT_MODE_CREDIT\n",
+        "    payment = payments.loc[payments['invoice_numbers'] == invoice['invoice_number']].to_dict('records')\n",
+        "    if len(payment) > 1:\n",
+        "      print(\"WARNING : More than one payments found for invoice : {invoice_number}. Will only take the first payment.\".format(invoice_number=invoice['invoice_number']))\n",
+        "    payment_mode = payment[0]['payment_mode'] if payment else PAYMENT_MODE_CREDIT\n",
         "    invoice_table.append_row(invoice=invoice, payment_mode=payment_mode)\n",
         "    for item in invoice['line_items']:\n",
         "      sales_type_table.append_row(item=item, payment_mode=payment_mode)\n",
@@ -792,13 +809,6 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rqsl3a8n8LTL"
-      },
-      "source": []
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
@@ -858,6 +868,9 @@
   ],
   "metadata": {
     "colab": {
+      "collapsed_sections": [
+        "fhcat8bigmYk"
+      ],
       "provenance": [],
       "include_colab_link": true
     },


### PR DESCRIPTION
Multiple changes:
- Use `ratelimit` as rate limiter for every Zoho Api call.
- Simplify logic for computing amount including GST.
- Fetch all payments for the time period instead of fetching payments per invoice.
- Use `tqdm` to show progress for long running operation.